### PR TITLE
Implement enhanced error messages with color support (issue #6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,39 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## ⚠️ CRITICAL: NetCDF Dependency Configuration ⚠️
+
+**NEVER CHANGE THE NETCDF DEPENDENCY CONFIGURATION IN fpm.toml**
+
+This project MUST use the system-installed NetCDF library, NOT a git dependency.
+
+### Correct Configuration (DO NOT CHANGE):
+
+```toml
+[build]
+external-modules = ["netcdf"]
+link = ["netcdff"]
+
+[dependencies]
+fortran-s3-accessor = { git = "...", tag = "vX.Y.Z" }
+stdlib = "*"
+
+# Note: NetCDF Fortran uses system-installed library (linked via [build] section above)
+```
+
+### FORBIDDEN Configuration (NEVER USE):
+
+```toml
+# ❌ NEVER DO THIS ❌
+[dependencies]
+netcdf-fortran = { git = "https://github.com/LKedward/netcdf-interfaces.git" }
+netcdf-interfaces = { git = "https://github.com/LKedward/netcdf-interfaces.git" }
+```
+
+**Why:** The git-based netcdf wrappers require `-fallow-argument-mismatch` flags, have type mismatch issues, are fragile across compiler versions, and cause build failures. The system-installed approach is stable, tested, and works reliably.
+
+**If you are ever tempted to change this:** DON'T. Just use the system NetCDF library.
+
 ## Project Overview
 
 NetCDF integration for `fortran-s3-accessor` - provides transparent S3 URIs with automatic cleanup and optimal temp file management. This is a Fortran package built with FPM that enables direct opening of NetCDF files from S3 URIs using `s3_nf90_open()` as a drop-in replacement for `nf90_open()`.
@@ -25,8 +58,9 @@ fpm build --profile release
 
 ### Dependencies
 
-- **fortran-s3-accessor**: Uses git dependency `{ git = "https://github.com/pgierz/fortran-s3-accessor.git", tag = "v1.1.0" }`
-- **netcdf-fortran**: Uses LKedward's interface wrapper `{ git = "https://github.com/LKedward/netcdf-interfaces.git" }`
+- **fortran-s3-accessor**: Uses git dependency `{ git = "https://github.com/pgierz/fortran-s3-accessor.git", tag = "v1.1.1" }`
+- **stdlib**: Fortran standard library (metapackage in FPM 0.9.0+)
+- **netcdf-fortran**: Uses system-installed library (see critical note above)
 
 ## Running Tests
 
@@ -138,18 +172,23 @@ Uses `get_pid()` subroutine to generate unique temp filenames:
 
 ### Performance Characteristics
 
-With fortran-s3-accessor v1.1.0:
+With fortran-s3-accessor v1.1.1:
 - **Network → Memory**: Direct streaming via POSIX popen (no disk I/O during download)
 - **Memory → Temp**: Single write to RAM disk (Linux) or /tmp
 - **Overhead**: ~10ms for small files, ~10-30% for large files vs direct S3 access
 
 ### Error Handling
 
+The module provides enhanced error messages with context and diagnostics:
+
+**Verbose mode:** Set `S3_NETCDF_VERBOSE` environment variable to enable detailed logging
+**Color output:** Automatic ANSI color codes in terminals (disable with `NO_COLOR=1`)
+
 Returns standard NetCDF error codes:
-- `NF90_EINVAL` - S3 download failed or invalid URI
+- `NF90_EINVAL` - Invalid S3 URI or download failed (with detailed error context)
 - `NF90_EMAXNAME` - Too many open handles (>100)
-- `NF90_EPERM` - Cannot create or write temp file (permission denied)
-- All other `nf90_*` errors pass through from NetCDF library
+- `NF90_EPERM` - Cannot create or write temp file (with path and diagnostics)
+- All other `nf90_*` errors pass through from NetCDF library (with context)
 
 ## Critical Usage Rules
 
@@ -175,7 +214,7 @@ status = s3_nf90_close(ncid)  ! Cleanup happens here
 
 **Completed migration**:
 - ✅ Moved to standalone repository
-- ✅ Git dependency on fortran-s3-accessor v1.1.0
+- ✅ Git dependency on fortran-s3-accessor v1.1.1 (path-style S3 support)
 - ✅ Issue templates and PR template
 - ✅ Project milestones (v0.1.0, v0.2.0, v1.0.0)
 - ✅ Comprehensive issue tracking for all planned features
@@ -183,8 +222,9 @@ status = s3_nf90_close(ncid)  ! Cleanup happens here
 
 ## Related Work
 
-**Parent library**: [fortran-s3-accessor](https://github.com/pgierz/fortran-s3-accessor) v1.1.0
+**Parent library**: [fortran-s3-accessor](https://github.com/pgierz/fortran-s3-accessor) v1.1.1
 - Provides generic S3 GET/PUT operations with direct memory streaming
+- Path-style S3 URL support (critical for MinIO and some S3-compatible services)
 - Comprehensive logging via `s3_logger` module
 - Platform support: Linux/macOS (native streaming), Windows (temp file fallback)
 


### PR DESCRIPTION
## Summary

Implements comprehensive error handling improvements for better diagnostics and user experience:

- ✅ URI validation before S3 download with detailed error messages
- ✅ Enhanced error context for all failure modes (S3 download, temp file creation, NetCDF open)
- ✅ Verbose logging mode via `S3_NETCDF_VERBOSE` environment variable
- ✅ ANSI color codes: errors (red), warnings (yellow), verbose (gray)
- ✅ Color output respects `TERM` and `NO_COLOR` environment variables

## Dependency Fixes

**Critical fix:** Restored system NetCDF library configuration
- ❌ Removed broken `netcdf-interfaces` git dependency (causes type mismatch errors)
- ✅ Restored `external-modules = ["netcdf"]` and `link = ["netcdff"]`
- ✅ Updated `fortran-s3-accessor` to v1.1.1 (path-style S3 support)
- ✅ Re-enabled auto-tests and restored test-drive dev-dependency

## Documentation

- Added **CRITICAL** warning section in CLAUDE.md about NetCDF dependency
- Updated all references from v1.1.0 to v1.1.1
- Documented verbose mode and color output features
- Updated error code documentation

## Example Output

**Without verbose mode:**
```
[S3_NETCDF ERROR] Invalid URI format: URI must start with s3://
[S3_NETCDF ERROR]   URI: http://example.com/file.nc
```

**With S3_NETCDF_VERBOSE=1:**
```
[S3_NETCDF] Verbose mode enabled
[S3_NETCDF] Opening S3 URI: s3://bucket/data/file.nc
[S3_NETCDF] Downloading from S3...
[S3_NETCDF] Downloaded 1048576 bytes
[S3_NETCDF] Using temp directory: /dev/shm
[S3_NETCDF] Creating temp file: /dev/shm/s3_netcdf_12345_1.nc
[S3_NETCDF] Wrote 1048576 bytes to temp file
[S3_NETCDF] Opening temp file with NetCDF...
[S3_NETCDF] Successfully opened NetCDF file (ncid=65536)
```

## Testing

- ✅ Build passes with system NetCDF library
- ⏳ Unit tests needed for error cases (follow-up work)

## Closes

#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement enhanced error handling and logging with colorized and verbose diagnostics, restore and correct NetCDF build configuration, update dependencies and re-enable tests, and refresh documentation accordingly

New Features:
- Add verbose logging mode via S3_NETCDF_VERBOSE environment variable
- Introduce ANSI-colored logging for errors (red), warnings (yellow), and verbose messages (gray) respecting TERM and NO_COLOR
- Validate S3 URI format before download to catch malformed URIs early
- Provide detailed diagnostic error messages for S3 download, temporary file creation/write, and NetCDF open/close failures

Enhancements:
- Restore system NetCDF library configuration and remove broken netcdf-interfaces git dependency
- Bump fortran-s3-accessor dependency to v1.1.1 and add stdlib metapackage
- Re-enable auto-tests and add test-drive as a development dependency

Build:
- Enable auto-tests and configure external-modules and link settings for NetCDF in fpm.toml

Documentation:
- Add critical guidance on NetCDF dependency in CLAUDE.md
- Update version references to v1.1.1, document verbose mode and color output, and revise error code documentation

Tests:
- Re-enable auto-tests in fpm.toml and integrate test-drive for error case coverage